### PR TITLE
Update texture for DragonFlight

### DIFF
--- a/Diminish_Options/widgets/header.lua
+++ b/Diminish_Options/widgets/header.lua
@@ -44,7 +44,7 @@ function Widgets:CreateSubHeader(parent, text)
     title:SetText(text)
     title:SetPoint("TOPLEFT", anchor, "BOTTOMLEFT", 0, -3)
 
-    local underline = anchor:CreateTexture(nil, "ARTWORK", "videoSubUnderline")
+    local underline = anchor:CreateTexture(nil, "ARTWORK", "_UI-Frame-BtnBotTile")
     underline:ClearAllPoints()
     underline:SetPoint("TOPLEFT", title, "BOTTOMLEFT", 0, -3)
 


### PR DESCRIPTION
The old texture was removed and is causing the options panel to crash on load. This replacement texture seems to be in both current retail and the new DragonFlight (along with wrath/classic from a quick lookup). All other options seem to work in DragonFlight without issues! (so far).

Example:
![diminish-2](https://user-images.githubusercontent.com/574637/193681949-04818bdf-bb81-403f-bb17-f5c43b00ebdc.JPG)


I know this is in maintenance mode but was a easy fix to get it working. 

If you wish I could also maybe bind on `DIMINISH_NS.IS_NOT_RETAIL` and only change it for retail.

Thanks for all your work on this project!
